### PR TITLE
Fix Voice-to-Recipe error message quoting

### DIFF
--- a/components/recipe/voice-to-recipe.tsx
+++ b/components/recipe/voice-to-recipe.tsx
@@ -332,7 +332,7 @@ export function VoiceToRecipe({ recipe, onUpdate }: VoiceToRecipeProps) {
       console.log('Voice update response:', data)
       
       if (!data.changes || data.changes.length === 0) {
-        setError('I couldn\'t understand what changes you want to make. Please try speaking more clearly.')
+        setError("I couldn't understand what changes you want to make. Please try speaking more clearly.")
         return
       }
       


### PR DESCRIPTION
## Summary
- fix escaping for the "I couldn't..." message in voice-to-recipe component
- align indentation with surrounding code

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68582145756883328d66079cfc1fc878